### PR TITLE
Add app module that will allow to create iis applications.

### DIFF
--- a/iis_bridge/app.py
+++ b/iis_bridge/app.py
@@ -1,0 +1,40 @@
+"""
+    This module is used for manipulating iis applications
+    :copyright: (c) 2014 by Kourosh Parsa.
+"""
+
+import iis_bridge.config as config
+
+
+def exists(site_name, app_path):
+    """ given the site name and app path, returns whether
+    the application already exists
+    Parameters:
+    - site_name: name of iis site that contains the application
+    - app_path: virtual path of the application, e.g. "/my_app"
+    """
+    full_app_path = site_name + app_path
+    cmd = "%s list apps %s" % (config.APP_CMD, full_app_path)
+    output = config.run(cmd)
+    for line in output.splitlines():
+        if line.split('"')[1] == full_app_path:
+            return True
+    return False
+
+
+def create(site_name, app_path, physical_path=None):
+    """ creates a new iis application
+    Parameters:
+    - site_name: name of iis site that will contain the application
+    - app_path: virtual path of the application, e.g. "/my_app"
+    - physical_path: the directory of the application
+    """
+    if exists(site_name, app_path):
+        print("%s already exists in %s." % (app_path, site_name))
+        return
+
+    cmd = "%s add app /site.name:\"%s\" /path:\"%s\"" \
+          % (config.APP_CMD, site_name, app_path)
+    if physical_path:
+        cmd += " /physicalPath:\"%s\"" % physical_path
+    config.run(cmd)


### PR DESCRIPTION
This changes should allow to create iis applications using iis_bridge.
This pull request adds an **app.py** module with **create** function.
Usage:

    from iis_bridge import app
    app.create(site_name='test_site', app_path='/my_app', physical_path='C:/inetpub/wwwroot_test_site/myapp')


Under the hood, it uses *appcmd.exe add app* command.
I've tried to write this code to follow conventions from other modules (pool, site).

This module could be extended with other application related features like: set configuration, delete application. I think that I could add those features if author is willing to add this application module to the library.